### PR TITLE
Fixed shutdown bug on server start

### DIFF
--- a/src/main/java/io/playpen/core/p3/PackageManager.java
+++ b/src/main/java/io/playpen/core/p3/PackageManager.java
@@ -264,7 +264,7 @@ public class PackageManager {
                         P3Package.PackageStepConfig config = new P3Package.PackageStepConfig();
                         config.setStep(step);
                         config.setConfig(obj);
-                        p3.getExecutionSteps().add(config);
+                        p3.getShutdownSteps().add(config);
                     }
                 }
             }


### PR DESCRIPTION
When a service is started with a shutdown step, the shutdown step is executed just after the execution step because of an error in the code in the PackageManager.